### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://pascaldemo.visualstudio.com/522514be-8f96-4994-a57c-7152af5263bb/06b52da1-b776-48f6-a3d0-097a52023365/_apis/work/boardbadge/e2bd363a-f7af-463e-807e-b80e1093ecf0)](https://pascaldemo.visualstudio.com/522514be-8f96-4994-a57c-7152af5263bb/_boards/board/t/06b52da1-b776-48f6-a3d0-097a52023365/Microsoft.RequirementCategory)
 # hello-world
 Making some edits as suggested by the tutorial.
 Making some more edits using Sublime3 text editor


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#792](https://pascaldemo.visualstudio.com/522514be-8f96-4994-a57c-7152af5263bb/_workitems/edit/792). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.